### PR TITLE
Enable post-merge dev mode

### DIFF
--- a/Dockerfile.l1
+++ b/Dockerfile.l1
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.13.0
+FROM ethereum/client-go:v1.13.14
 
 RUN apk add --no-cache jq curl
 
@@ -6,6 +6,6 @@ COPY entrypoint-l1.sh /entrypoint.sh
 
 VOLUME ["/db"]
 
-HEALTHCHECK --start-period=300s --start-interval=1s CMD curl --fail http://localhost:8545 -X POST -H "Content-Type: application/json" --data '{"method":"eth_chainId","params":[],"id":1,"jsonrpc":"2.0"}'
+# HEALTHCHECK --start-period=300s --start-interval=1s CMD curl --fail http://localhost:8545 -X POST -H "Content-Type: application/json" --data '{"method":"eth_chainId","params":[],"id":1,"jsonrpc":"2.0"}'
 
 ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]

--- a/config/genesis-staging.json
+++ b/config/genesis-staging.json
@@ -14,10 +14,10 @@
     "londonBlock": 0,
     "arrowGlacierBlock": 0,
     "grayGlacierBlock": 0,
-    "clique": {
-      "period": 12,
-      "epoch": 30000
-    }
+    "shanghaiTime": 0,
+    "terminalTotalDifficulty": 0,
+    "terminalTotalDifficultyPassed": true,
+    "isDev": true
   },
   "nonce": "0x0",
   "timestamp": "0x6511b40b",

--- a/entrypoint-l1.sh
+++ b/entrypoint-l1.sh
@@ -38,6 +38,8 @@ fi
 # pruned within minutes of starting the devnet.
 
 exec geth \
+	--dev \
+	--dev.period=12 \
 	--datadir="$GETH_DATA_DIR" \
 	--verbosity="$VERBOSITY" \
 	--http \


### PR DESCRIPTION
- Enables querying "finalized" blocks.
- Update geth.

The post merge dev mode doesn't seem very well documented.

It was added in this PR:

https://github.com/ethereum/go-ethereum/pull/28463

To get a working genesis block, this workaround is needed

- geth --datadir /path/to/data --dev
- shut down geth
- geth --datadir /path/to/data dumpgenesis

Close #12